### PR TITLE
refactor: add getErrorMessage utility function

### DIFF
--- a/src/commands/checkpoint/checkpoint.ts
+++ b/src/commands/checkpoint/checkpoint.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { multiLayerPersistence } from "../../persistence/multi-layer";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Create a checkpoint for a task
@@ -35,9 +36,7 @@ export const checkpointCommand = new Command("checkpoint")
       console.log(`   Checkpoint ID: ${checkpointId}`);
       console.log(`   Description: ${description}`);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("❌ Failed to create checkpoint:", errorMessage);
+      console.error("❌ Failed to create checkpoint:", getErrorMessage(error));
       process.exit(1);
     }
   });

--- a/src/commands/checkpoint/restore-checkpoint.ts
+++ b/src/commands/checkpoint/restore-checkpoint.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { multiLayerPersistence } from "../../persistence/multi-layer";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Restore a task from a checkpoint
@@ -68,9 +69,10 @@ export const restoreCheckpointCommand = new Command("restore-checkpoint")
         console.log(`   Task Status: pending`);
         console.log(`   Task is ready to be resumed`);
       } catch (error: unknown) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error("❌ Failed to restore checkpoint:", errorMessage);
+        console.error(
+          "❌ Failed to restore checkpoint:",
+          getErrorMessage(error),
+        );
         process.exit(1);
       }
     },

--- a/src/commands/memory/find-task.ts
+++ b/src/commands/memory/find-task.ts
@@ -3,6 +3,7 @@
 
 import { Command } from "commander";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Search tasks by name or metadata with filters
@@ -72,9 +73,7 @@ export const findTaskCommand = new Command("find-task")
 
         displaySearchResults(matches, query, options);
       } catch (error: unknown) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error("❌ Failed to find tasks:", errorMessage);
+        console.error("❌ Failed to find tasks:", getErrorMessage(error));
         process.exit(1);
       }
     },

--- a/src/commands/memory/task-decisions.ts
+++ b/src/commands/memory/task-decisions.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { multiLayerPersistence } from "../../persistence/multi-layer";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Display agent decisions for a task
@@ -41,9 +42,10 @@ export const taskDecisionsCommand = new Command("task-decisions")
 
         displayDecisions(limited, taskId, filtered.length, limit);
       } catch (error: unknown) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error("❌ Failed to load task decisions:", errorMessage);
+        console.error(
+          "❌ Failed to load task decisions:",
+          getErrorMessage(error),
+        );
         process.exit(1);
       }
     },

--- a/src/commands/memory/task-executions.ts
+++ b/src/commands/memory/task-executions.ts
@@ -3,6 +3,7 @@
 
 import { Command } from "commander";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Display task execution statistics and details
@@ -24,9 +25,10 @@ export const taskExecutionsCommand = new Command("task-executions")
       // For now, we show task-level execution details
       displayExecutionInfo(task);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("❌ Failed to get task executions:", errorMessage);
+      console.error(
+        "❌ Failed to get task executions:",
+        getErrorMessage(error),
+      );
       process.exit(1);
     }
   });

--- a/src/commands/memory/task-history.ts
+++ b/src/commands/memory/task-history.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { multiLayerPersistence } from "../../persistence/multi-layer";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Display task execution history from JSONL logs
@@ -45,9 +46,10 @@ export const taskHistoryCommand = new Command("task-history")
 
         displayLogs(logs, taskId);
       } catch (error: unknown) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error("❌ Failed to load task history:", errorMessage);
+        console.error(
+          "❌ Failed to load task history:",
+          getErrorMessage(error),
+        );
         process.exit(1);
       }
     },

--- a/src/commands/memory/task-stats.ts
+++ b/src/commands/memory/task-stats.ts
@@ -3,6 +3,7 @@
 
 import { Command } from "commander";
 import { taskRegistry } from "../../task-registry/registry";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Display task statistics and distributions
@@ -39,9 +40,7 @@ export const taskStatsCommand = new Command("task-stats")
 
       displayStatistics(allTasks, statusCounts, ownerCounts);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("❌ Failed to get task stats:", errorMessage);
+      console.error("❌ Failed to get task stats:", getErrorMessage(error));
       process.exit(1);
     }
   });

--- a/src/commands/monitoring/health.ts
+++ b/src/commands/monitoring/health.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { health } from "../../monitoring/health";
 import { HealthStatus } from "../../monitoring/health";
+import { getErrorMessage } from "../../util/errors";
 
 /**
  * Display system health check results
@@ -100,9 +101,10 @@ export const healthCommand = new Command("health")
         process.exit(1);
       }
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("[FAIL] Failed to run health check:", errorMessage);
+      console.error(
+        "[FAIL] Failed to run health check:",
+        getErrorMessage(error),
+      );
       process.exit(1);
     }
   });

--- a/src/commands/monitoring/metrics.ts
+++ b/src/commands/monitoring/metrics.ts
@@ -3,6 +3,7 @@
 
 import { Command } from "commander";
 import { dashboard, getFormattedDashboard } from "../../monitoring/dashboard";
+import { getErrorMessage } from "../../util/errors";
 
 export const metricsCommand = new Command("metrics")
   .description("Show system metrics and performance data")
@@ -51,9 +52,7 @@ export const metricsCommand = new Command("metrics")
 
       console.log("\n" + "═".repeat(60) + "\n");
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.error("[FAIL] Failed to get metrics:", errorMessage);
+      console.error("[FAIL] Failed to get metrics:", getErrorMessage(error));
       process.exit(1);
     }
   });

--- a/src/util/__tests__/errors.test.ts
+++ b/src/util/__tests__/errors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "@jest/globals";
+import { getErrorMessage } from "../errors";
+
+describe("getErrorMessage", () => {
+  it("should extract message from Error instances", () => {
+    const error = new Error("Test error message");
+    expect(getErrorMessage(error)).toBe("Test error message");
+  });
+
+  it("should return string errors as-is", () => {
+    expect(getErrorMessage("String error")).toBe("String error");
+  });
+
+  it("should handle null with fallback", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error");
+    expect(getErrorMessage(null, "Custom fallback")).toBe("Custom fallback");
+  });
+
+  it("should handle undefined with fallback", () => {
+    expect(getErrorMessage(undefined)).toBe("Unknown error");
+    expect(getErrorMessage(undefined, "Custom fallback")).toBe(
+      "Custom fallback",
+    );
+  });
+
+  it("should handle objects with message property", () => {
+    const errorLike = { message: "Object error" };
+    expect(getErrorMessage(errorLike)).toBe("Object error");
+  });
+
+  it("should handle empty string with fallback", () => {
+    expect(getErrorMessage("")).toBe("Unknown error");
+  });
+
+  it("should handle Error with empty message", () => {
+    const error = new Error("");
+    expect(getErrorMessage(error)).toBe("Unknown error");
+  });
+
+  it("should stringify other types", () => {
+    expect(getErrorMessage(123)).toBe("123");
+    expect(getErrorMessage(true)).toBe("true");
+  });
+
+  it("should return fallback for plain objects", () => {
+    expect(getErrorMessage({ foo: "bar" })).toBe("Unknown error");
+  });
+});

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Extract a human-readable error message from an unknown error
+ *
+ * Safely handles all error types including:
+ * - Error instances (returns error.message)
+ * - String errors (returns as-is)
+ * - Objects with message property
+ * - null/undefined (returns fallback)
+ * - Everything else (returns String() representation)
+ *
+ * @param error - The caught error of unknown type
+ * @param fallback - Optional fallback message if error is empty/undefined
+ * @returns A string error message suitable for logging or display
+ */
+export function getErrorMessage(
+  error: unknown,
+  fallback = "Unknown error",
+): string {
+  if (error === null || error === undefined) {
+    return fallback;
+  }
+
+  if (error instanceof Error) {
+    return error.message || fallback;
+  }
+
+  if (typeof error === "string") {
+    return error || fallback;
+  }
+
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const msg = (error as { message: unknown }).message;
+    if (typeof msg === "string") {
+      return msg || fallback;
+    }
+  }
+
+  const stringified = String(error);
+  return stringified === "[object Object]" ? fallback : stringified;
+}


### PR DESCRIPTION
## Summary

Post-merge improvement from PR #24. Adds a reusable utility function for extracting error messages from unknown error types.

## Changes

- **New utility**: `src/util/errors.ts` - `getErrorMessage(error, fallback?)`
  - Handles Error instances (returns `error.message`)
  - Handles string errors (returns as-is)
  - Handles null/undefined (returns fallback)
  - Handles objects with message property
  - Handles everything else (returns String() representation)

- **Updated commands** to use the utility:
  - `src/commands/checkpoint/checkpoint.ts`
  - `src/commands/checkpoint/restore-checkpoint.ts`
  - `src/commands/memory/find-task.ts`
  - `src/commands/memory/task-decisions.ts`
  - `src/commands/memory/task-executions.ts`
  - `src/commands/memory/task-history.ts`
  - `src/commands/memory/task-stats.ts`
  - `src/commands/monitoring/health.ts`
  - `src/commands/monitoring/metrics.ts`

- **Tests**: `src/util/__tests__/errors.test.ts` - 9 test cases covering all edge cases

## Before

```typescript
} catch (error: unknown) {
  const errorMessage = error instanceof Error ? error.message : String(error);
  console.error("❌ Failed:", errorMessage);
}
```

## After

```typescript
import { getErrorMessage } from "../../util/errors";
// ...
} catch (error: unknown) {
  console.error("❌ Failed:", getErrorMessage(error));
}
```

## Test Plan

- [x] Type check passes
- [x] Unit tests pass (9/9)
- [x] CI passes