### PR TITLE
chore: Post-merge fixes after PostgreSQL integration

### DIFF
--- a/tests/hooks/plan-hooks.test.ts
+++ b/tests/hooks/plan-hooks.test.ts
@@ -20,8 +20,8 @@ describe("Plan Hooks", () => {
 
     test("should execute hook with taskId and agentId", async () => {
       const hook = createPlanFileCreatorHook();
-      // Hook logs internally (real file operations are placeholders)
-      await expect(hook("task-123", "agent-1")).rejects.toThrow();
+      // Hook returns undefined if task not found (graceful degradation)
+      await expect(hook("task-123", "agent-1")).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Test fix for plan-hooks to expect graceful degradation after PR #35 merge.

## Changes

- Update plan-hooks.test.ts to expect `resolves.toBeUndefined()` instead of `rejects.toThrow()` when task is not found
- This aligns with the graceful degradation behavior expected in production

## Related

- Follows PR #35 (PostgreSQL Integration)
- Resolves remaining issues from PR #35 merge